### PR TITLE
Decrease the memory size of app-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Decrease the memory size.
+
 ## [0.1.0] - 2020-08-25
 
 ### Added

--- a/helm/app-exporter/templates/deployment.yaml
+++ b/helm/app-exporter/templates/deployment.yaml
@@ -58,9 +58,9 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 100m
+            memory: 100Mi
           limits:
             cpu: 100m
-            memory: 100m
+            memory: 100Mi
       imagePullSecrets:
       - name: {{ include "resource.pullSecret.name" . }}

--- a/helm/app-exporter/templates/deployment.yaml
+++ b/helm/app-exporter/templates/deployment.yaml
@@ -58,9 +58,9 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 220Mi
+            memory: 100m
           limits:
             cpu: 100m
-            memory: 220Mi
+            memory: 100m
       imagePullSecrets:
       - name: {{ include "resource.pullSecret.name" . }}


### PR DESCRIPTION
According to the survey on Prometheus, the app-exporter is using 50M as a maximum. But I would like to have 100M for the wiggle room.

## Checklist

- [x] Update changelog in CHANGELOG.md.
