### PR TITLE
Extend app-operator ready alert for per cluster instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Extend app-operator ready metric to include per workload cluster instances.
+
 ### Changed
 
 - Get team from `AppCatalogEntry` CRs not mapping configmap.
 - Update apiextensions to v3 and replace CAPI with Giant Swarm fork.
-- Update `giantswarm/app` to `v4.2.0`.
 
 ## [0.2.1] - 2020-10-01
 

--- a/integration/test/metrics/metrics_test.go
+++ b/integration/test/metrics/metrics_test.go
@@ -93,14 +93,14 @@ func TestMetrics(t *testing.T) {
 			t.Fatalf("expected nil got %#q", err)
 		}
 
-		expectedMetric := fmt.Sprintf("app_operator_app_info{catalog=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"batman\",version=\"%s\"} 1",
+		expectedAppMetric := fmt.Sprintf("app_operator_app_info{catalog=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"batman\",version=\"%s\"} 1",
 			app.Spec.Catalog,
 			app.Name,
 			app.Namespace,
 			app.Status.Release.Status,
 			app.Spec.Version)
 
-		config.Logger.Debugf(ctx, "checking for expected metric\n%s", expectedMetric)
+		config.Logger.Debugf(ctx, "checking for expected app metric\n%s", expectedAppMetric)
 
 		respBytes, err := ioutil.ReadAll(metricsResp.Body)
 		if err != nil {
@@ -108,11 +108,21 @@ func TestMetrics(t *testing.T) {
 		}
 
 		metrics := string(respBytes)
-		if !strings.Contains(metrics, expectedMetric) {
-			t.Fatalf("expected metric\n\n%s\n\nnot found in response\n\n%s", expectedMetric, metrics)
+		if !strings.Contains(metrics, expectedAppMetric) {
+			t.Fatalf("expected app metric\n\n%s\n\nnot found in response\n\n%s", expectedAppMetric, metrics)
 		}
 
-		config.Logger.Debugf(ctx, "found expected metric")
+		config.Logger.Debugf(ctx, "found expected app metric")
+
+		expectedAppOperatorMetric := "app_operator_ready_total{namespace=\"giantswarm\",version=\"0.0.0\"} 1"
+
+		config.Logger.Debugf(ctx, "checking for expected app-operator metric\n%s", expectedAppOperatorMetric)
+
+		if !strings.Contains(metrics, expectedAppOperatorMetric) {
+			t.Fatalf("expected app metric\n\n%s\n\nnot found in response\n\n%s", expectedAppOperatorMetric, metrics)
+		}
+
+		config.Logger.Debugf(ctx, "found expected app-operator metric")
 	}
 }
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -20,6 +20,11 @@ func GitSHA() string {
 	return gitSHA
 }
 
+// Helm2AppVersion is always 1.0.0 for workload cluster app CRs using Helm 2.
+func Helm2AppVersion() string {
+	return "1.0.0"
+}
+
 func OperatorName() string {
 	return operatorName
 }
@@ -34,9 +39,4 @@ func Source() string {
 
 func Version() string {
 	return version
-}
-
-// WorkloadAppVersion is always 1.0.0 for workload cluster app CRs using Helm 2.
-func WorkloadAppVersion() string {
-	return "1.0.0"
 }

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,18 +5,12 @@ const (
 )
 
 var (
-	description = "The app-exporter does something."
+	description = "The app-exporter is a Prometheus exporter for the Giant Swarm App Platform."
 	gitSHA      = "n/a"
 	name        = "app-exporter"
 	source      = "https://github.com/giantswarm/app-exporter"
 	version     = "0.2.2-dev"
 )
-
-// AppTenantVersion is always 1.0.0 for tenant cluster app CRs using Helm 2.
-// For app CRs using Helm 3 we use project.Version().
-func AppTenantVersion() string {
-	return "1.0.0"
-}
 
 func Description() string {
 	return description
@@ -40,4 +34,9 @@ func Source() string {
 
 func Version() string {
 	return version
+}
+
+// WorkloadAppVersion is always 1.0.0 for workload cluster app CRs using Helm 2.
+func WorkloadAppVersion() string {
+	return "1.0.0"
 }

--- a/service/collector/app_operator.go
+++ b/service/collector/app_operator.go
@@ -125,7 +125,7 @@ func (a *AppOperator) collectAppOperatorStatus(ctx context.Context, ch chan<- pr
 				appOperatorDesc,
 				prometheus.GaugeValue,
 				float64(ready),
-				namespace,
+				"giantswarm",
 				version,
 			)
 		}

--- a/service/collector/app_operator.go
+++ b/service/collector/app_operator.go
@@ -149,6 +149,8 @@ func (a *AppOperator) collectAppVersions(ctx context.Context) (map[string]map[st
 		appNamespaces, ok := appVersions[version]
 		if ok {
 			continue
+		} else {
+			appNamespaces = map[string]bool{}
 		}
 
 		namespace := app.Namespace

--- a/service/collector/app_operator.go
+++ b/service/collector/app_operator.go
@@ -82,10 +82,14 @@ func (a *AppOperator) collectAppOperatorStatus(ctx context.Context, ch chan<- pr
 		return microerror.Mask(err)
 	}
 
+	a.logger.Debugf(ctx, "APP VERSIONS %#v", appVersions)
+
 	operatorVersions, err := a.collectOperatorVersions(ctx)
 	if err != nil {
 		return microerror.Mask(err)
 	}
+
+	a.logger.Debugf(ctx, "OPERATOR VERSIONS %#v", operatorVersions)
 
 	for version := range appVersions {
 		instances, ok := operatorVersions[version]

--- a/service/collector/app_operator.go
+++ b/service/collector/app_operator.go
@@ -157,7 +157,7 @@ func (a *AppOperator) collectOperatorVersions(ctx context.Context) (map[string]m
 	lo := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", label.App, project.OperatorName()),
 	}
-	d, err := a.k8sClient.K8sClient().AppsV1().Deployments("giantswarm").List(ctx, lo)
+	d, err := a.k8sClient.K8sClient().AppsV1().Deployments("").List(ctx, lo)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/collector/app_operator.go
+++ b/service/collector/app_operator.go
@@ -165,10 +165,6 @@ func (a *AppOperator) collectAppVersions(ctx context.Context) (map[string]map[st
 			namespace = "giantswarm"
 		}
 
-		appNamespaces = map[string]bool{
-			namespace: true,
-		}
-
 		appNamespaces[namespace] = true
 		appVersions[version] = appNamespaces
 	}

--- a/service/collector/app_operator.go
+++ b/service/collector/app_operator.go
@@ -102,12 +102,12 @@ func (a *AppOperator) collectAppOperatorStatus(ctx context.Context, ch chan<- pr
 		}
 
 		for namespace, ready := range instances {
-			if version == project.AppTenantVersion() {
+			if version == project.WorkloadAppVersion() {
 				// There should be a single app-operator instance with major version
-				// 1 for Helm 2 tenant clusters.
+				// 1 for Helm 2 workload clusters.
 				ready, err = helm2AppOperatorReady(operatorVersions)
 				if err != nil {
-					a.logger.Errorf(ctx, err, "failed to check helm 2 app-operator ready")
+					a.logger.Errorf(ctx, err, "failed to check helm 2 %#q ready", project.OperatorName())
 					ready = 0
 				}
 			}

--- a/service/collector/app_operator.go
+++ b/service/collector/app_operator.go
@@ -147,24 +147,26 @@ func (a *AppOperator) collectAppVersions(ctx context.Context) (map[string]map[st
 	for _, app := range l.Items {
 		version := app.Labels[label.AppOperatorVersion]
 		appNamespaces, ok := appVersions[version]
-		if !ok {
-			namespace := app.Namespace
+		if ok {
+			continue
+		}
 
-			v, err := semver.NewVersion(version)
-			if err != nil {
-				a.logger.Errorf(ctx, err, "failed to parse version %#q", version)
-				continue
-			}
-			if v.Major() < 4 {
-				// If the app-operator version is >= 4.0.0 it will be running in
-				// the workload cluster namespace. For older releases we just
-				// need to check the giantswarm namespace.
-				namespace = "giantswarm"
-			}
+		namespace := app.Namespace
 
-			appNamespaces = map[string]bool{
-				namespace: true,
-			}
+		v, err := semver.NewVersion(version)
+		if err != nil {
+			a.logger.Errorf(ctx, err, "failed to parse version %#q", version)
+			continue
+		}
+		if v.Major() < 4 {
+			// If the app-operator version is >= 4.0.0 it will be running in
+			// the workload cluster namespace. For older releases we just
+			// need to check the giantswarm namespace.
+			namespace = "giantswarm"
+		}
+
+		appNamespaces = map[string]bool{
+			namespace: true,
 		}
 
 		appNamespaces[namespace] = true

--- a/service/collector/app_operator_test.go
+++ b/service/collector/app_operator_test.go
@@ -8,49 +8,67 @@ import (
 func Test_helm2AppOperatorReady(t *testing.T) {
 	tests := []struct {
 		name             string
-		operatorVersions map[string]int32
+		operatorVersions map[string]map[string]int32
 		expectedResult   int32
 		hasError         bool
 	}{
 		{
 			name: "case 0: correct operator versions",
-			operatorVersions: map[string]int32{
-				"0.0.0": 1,
-				"1.0.9": 1,
-				"2.0.0": 1,
+			operatorVersions: map[string]map[string]int32{
+				"0.0.0": {
+					"giantswarm": 1,
+				},
+				"1.0.9": {
+					"giantswarm": 1,
+				},
+				"2.0.0": {
+					"giantswarm": 1,
+				},
 			},
 			expectedResult: 1,
 		},
 		{
 			name: "case 1: helm 2 operator not ready",
-			operatorVersions: map[string]int32{
-				"0.0.0": 1,
-				"1.0.9": 0,
-				"2.0.0": 1,
+			operatorVersions: map[string]map[string]int32{
+				"0.0.0": {
+					"giantswarm": 1,
+				},
+				"1.0.9": {
+					"giantswarm": 0,
+				},
+				"2.0.0": {
+					"giantswarm": 1,
+				},
 			},
 			expectedResult: 0,
 		},
 		{
 			name: "case 2: helm 2 operator missing",
-			operatorVersions: map[string]int32{
-				"0.0.0": 1,
-				"2.0.0": 1,
+			operatorVersions: map[string]map[string]int32{
+				"0.0.0": {
+					"giantswarm": 1,
+				},
+				"2.0.0": {
+					"giantswarm": 1,
+				},
 			},
 			expectedResult: 0,
 		},
 		{
 			name: "case 3: multiple helm 2 operators",
-			operatorVersions: map[string]int32{
-				"0.0.0": 0,
-				"1.0.9": 1,
-				"1.1.0": 1,
-				"2.0.0": 0,
+			operatorVersions: map[string]map[string]int32{
+				"1.0.9": {
+					"giantswarm": 1,
+				},
+				"1.1.0": {
+					"giantswarm": 1,
+				},
 			},
 			expectedResult: 2,
 		},
 		{
 			name:             "case 4: no versions",
-			operatorVersions: map[string]int32{},
+			operatorVersions: map[string]map[string]int32{},
 			expectedResult:   0,
 		},
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14163

Adds the namespace label to the metrics and extends them to cover per cluster instances of app-operator.

```sh
curl -s http://localhost:8000/metrics | grep ready
# HELP app_operator_ready_total Gauge with ready app-operator instances per app CR version.
# TYPE app_operator_ready_total gauge
app_operator_ready_total{namespace="fuqz3",version="4.0.0"} 1
app_operator_ready_total{namespace="giantswarm",version="0.0.0"} 1
app_operator_ready_total{namespace="giantswarm",version="1.0.0"} 1
app_operator_ready_total{namespace="giantswarm",version="2.7.0"} 1
app_operator_ready_total{namespace="giantswarm",version="3.1.0"} 1
app_operator_ready_total{namespace="kkr9u",version="4.0.0"} 1
```

## Checklist

- [x] Update changelog in CHANGELOG.md.
