### PR TITLE
Add app label to app metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
+- Add app label to app metrics with the name of the app.
 - Get team from `application.giantswarm.io/team` or `application.giantswarm.io/owners`
 annotations in Chart.yaml. 
 

--- a/integration/test/metrics/metrics_test.go
+++ b/integration/test/metrics/metrics_test.go
@@ -93,7 +93,8 @@ func TestMetrics(t *testing.T) {
 			t.Fatalf("expected nil got %#q", err)
 		}
 
-		expectedMetric := fmt.Sprintf("app_operator_app_info{catalog=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"batman\",version=\"%s\"} 1",
+		expectedMetric := fmt.Sprintf("app_operator_app_info{app=\"%s\",catalog=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"batman\",version=\"%s\"} 1",
+			app.Spec.Name,
 			app.Spec.Catalog,
 			app.Name,
 			app.Namespace,

--- a/service/collector/app.go
+++ b/service/collector/app.go
@@ -27,6 +27,7 @@ var (
 			labelTeam,
 			labelVersion,
 			labelCatalog,
+			labelApp,
 		},
 		nil,
 	)
@@ -130,6 +131,7 @@ func (a *App) collectAppStatus(ctx context.Context, ch chan<- prometheus.Metric)
 			// Getting version from spec, not status since the version in the spec is the desired version.
 			app.Spec.Version,
 			app.Spec.Catalog,
+			app.Spec.Name,
 		)
 
 		if !key.IsAppCordoned(app) {

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -6,6 +6,7 @@ const (
 )
 
 const (
+	labelApp       = "app"
 	labelCatalog   = "catalog"
 	labelName      = "name"
 	labelNamespace = "namespace"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15944

Adds an app label to the metrics with .Spec.Name from the app CR. This is needed as the name label shows the name of the app CR which may not match the app.

```
app_operator_app_info{app="node-exporter-app",catalog="default",name="node-exporter",namespace="zu8pw",status="deployed",team="batman",version="1.7.0"} 1
```

## Checklist

- [x] Update changelog in CHANGELOG.md.
