### PR TITLE
Get team from App CR annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Get team from `application.giantswarm.io/team` annotation on the App CR if it
+exists. Otherwise check the AppCatalogEntry CR.
+
 ## [0.3.0] - 2021-03-02
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/giantswarm/apiextensions/v3 v3.19.0
-	github.com/giantswarm/app/v4 v4.6.1-0.20210304165907-816e94343f7e
+	github.com/giantswarm/app/v4 v4.7.0
 	github.com/giantswarm/apptest v0.10.2
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/exporterkit v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/giantswarm/apiextensions/v3 v3.19.0
-	github.com/giantswarm/app/v4 v4.5.0
+	github.com/giantswarm/app/v4 v4.6.1-0.20210304165907-816e94343f7e
 	github.com/giantswarm/apptest v0.10.2
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/exporterkit v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/giantswarm/apiextensions/v3 v3.18.1 h1:vbGH0u9MyPIum2QGm+ehTGm/9B1Na5
 github.com/giantswarm/apiextensions/v3 v3.18.1/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
 github.com/giantswarm/apiextensions/v3 v3.19.0 h1:+rw3omC3pKtxLi53gc46sMuQ3LnYNXuPDK3SLS+mnug=
 github.com/giantswarm/apiextensions/v3 v3.19.0/go.mod h1:6KBexBTOZJ+amkorxw722t2HS57f+rf/8LeSSFfQNmo=
-github.com/giantswarm/app/v4 v4.5.0 h1:rube5PZdOOrIqS1tzytLn9/PrQFcyWAVxdp9/8HlWb0=
-github.com/giantswarm/app/v4 v4.5.0/go.mod h1:Y7NVYdN5dWFZ9ueIwVl7QNJnPUzup34Lzr85PI5Zj1k=
+github.com/giantswarm/app/v4 v4.6.1-0.20210304165907-816e94343f7e h1:vPJ0cXS8X57kOa932ZSVlLos68tNX/kbQOuATvfLJY0=
+github.com/giantswarm/app/v4 v4.6.1-0.20210304165907-816e94343f7e/go.mod h1:Y7NVYdN5dWFZ9ueIwVl7QNJnPUzup34Lzr85PI5Zj1k=
 github.com/giantswarm/appcatalog v0.4.0 h1:d1EltSPAJu/H6R8NHEf7kGvM4HTMktxDQdIUH2L+jw4=
 github.com/giantswarm/appcatalog v0.4.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v0.10.2 h1:wpTI+GkRr4zpV78e5u/BsdRB8AcKQaf7JPUiO8VIiU0=

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/giantswarm/apiextensions/v3 v3.18.1 h1:vbGH0u9MyPIum2QGm+ehTGm/9B1Na5
 github.com/giantswarm/apiextensions/v3 v3.18.1/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
 github.com/giantswarm/apiextensions/v3 v3.19.0 h1:+rw3omC3pKtxLi53gc46sMuQ3LnYNXuPDK3SLS+mnug=
 github.com/giantswarm/apiextensions/v3 v3.19.0/go.mod h1:6KBexBTOZJ+amkorxw722t2HS57f+rf/8LeSSFfQNmo=
-github.com/giantswarm/app/v4 v4.6.1-0.20210304165907-816e94343f7e h1:vPJ0cXS8X57kOa932ZSVlLos68tNX/kbQOuATvfLJY0=
-github.com/giantswarm/app/v4 v4.6.1-0.20210304165907-816e94343f7e/go.mod h1:Y7NVYdN5dWFZ9ueIwVl7QNJnPUzup34Lzr85PI5Zj1k=
+github.com/giantswarm/app/v4 v4.7.0 h1:6alWYu1HyAMl1f9h+/snuLi0PU3NYgoo1TQJBky15uc=
+github.com/giantswarm/app/v4 v4.7.0/go.mod h1:Y7NVYdN5dWFZ9ueIwVl7QNJnPUzup34Lzr85PI5Zj1k=
 github.com/giantswarm/appcatalog v0.4.0 h1:d1EltSPAJu/H6R8NHEf7kGvM4HTMktxDQdIUH2L+jw4=
 github.com/giantswarm/appcatalog v0.4.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v0.10.2 h1:wpTI+GkRr4zpV78e5u/BsdRB8AcKQaf7JPUiO8VIiU0=

--- a/service/collector/app.go
+++ b/service/collector/app.go
@@ -170,8 +170,16 @@ func (a *App) getOwningTeam(ctx context.Context, app v1alpha1.App, owners []owne
 	return "", nil
 }
 
+// getTeam returns the team to assign for this app CR. It first checks the App CR.
+// If the team annotation does not exist it checks the AppCatalogEntry CR. Finally
+// it returns the default team so metrics always have a team.
 func (a *App) getTeam(ctx context.Context, app v1alpha1.App) (string, error) {
 	var team string
+
+	// Team annotation on the App CR takes precedence if it exists.
+	if key.AppTeam(app) != "" {
+		return key.AppTeam(app), nil
+	}
 
 	name := key.AppCatalogEntryName(key.CatalogName(app), key.AppName(app), key.Version(app))
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16061

Check the App CR for the team annotation before checking the AppCatalogEntry CR. This lets the user override the value in Chart.yaml.

```
kg get app app-exporter-unique -o yaml | k neat
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  annotations:
    application.giantswarm.io/team: robin
...
  name: app-exporter-unique
  namespace: giantswarm
spec:
  catalog: control-plane-test-catalog
  kubeConfig:
    inCluster: true
  name: app-exporter
  namespace: giantswarm
  version: 0.3.0-0382a48359522e3221ac1c78c2003609baacc2be

curl -s http://localhost:8000/metrics | grep app-exporter
app_operator_app_info{app="app-exporter",catalog="control-plane-test-catalog",name="app-exporter-unique",namespace="giantswarm",status="deployed",team="robin",version="0.3.0-0382a48359522e3221ac1c78c2003609baacc2be"} 1
```

## Checklist

- [x] Update changelog in CHANGELOG.md.
