### PR TITLE
Expose desired version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `deployed_version`, `version_mismatch` label to app metrics.
+
 ### Changed
 
 - Prepare helm values to configuration management.

--- a/integration/test/metrics/metrics_test.go
+++ b/integration/test/metrics/metrics_test.go
@@ -94,7 +94,7 @@ func TestMetrics(t *testing.T) {
 			t.Fatalf("expected nil got %#q", err)
 		}
 
-		expectedAppMetric := fmt.Sprintf("app_operator_app_info{app=\"%s\",catalog=\"%s\",desired_version=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"batman\",version=\"%s\",version_mismatch=\"%s\"} 1",
+		expectedAppMetric := fmt.Sprintf("app_operator_app_info{app=\"%s\",catalog=\"%s\",deployed_version=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"batman\",version=\"%s\",version_mismatch=\"%s\"} 1",
 			app.Spec.Name,
 			app.Spec.Catalog,
 			app.Status.Version,

--- a/integration/test/metrics/metrics_test.go
+++ b/integration/test/metrics/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -93,14 +94,15 @@ func TestMetrics(t *testing.T) {
 			t.Fatalf("expected nil got %#q", err)
 		}
 
-		expectedAppMetric := fmt.Sprintf("app_operator_app_info{app=\"%s\",catalog=\"%s\",desired_version=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"batman\",version=\"%s\"} 1",
+		expectedAppMetric := fmt.Sprintf("app_operator_app_info{app=\"%s\",catalog=\"%s\",desired_version=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"batman\",version=\"%s\",version_mismatch=\"%s\"} 1",
 			app.Spec.Name,
 			app.Spec.Catalog,
 			app.Status.Version,
 			app.Name,
 			app.Namespace,
 			app.Status.Release.Status,
-			app.Spec.Version)
+			app.Spec.Version,
+			strconv.FormatBool(app.Spec.Version == app.Status.Version))
 
 		config.Logger.Debugf(ctx, "checking for expected app metric\n%s", expectedAppMetric)
 

--- a/integration/test/metrics/metrics_test.go
+++ b/integration/test/metrics/metrics_test.go
@@ -102,7 +102,7 @@ func TestMetrics(t *testing.T) {
 			app.Namespace,
 			app.Status.Release.Status,
 			app.Spec.Version,
-			strconv.FormatBool(app.Spec.Version == app.Status.Version))
+			strconv.FormatBool(app.Spec.Version != app.Status.Version))
 
 		config.Logger.Debugf(ctx, "checking for expected app metric\n%s", expectedAppMetric)
 

--- a/integration/test/metrics/metrics_test.go
+++ b/integration/test/metrics/metrics_test.go
@@ -93,9 +93,10 @@ func TestMetrics(t *testing.T) {
 			t.Fatalf("expected nil got %#q", err)
 		}
 
-		expectedAppMetric := fmt.Sprintf("app_operator_app_info{app=\"%s\",catalog=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"batman\",version=\"%s\"} 1",
+		expectedAppMetric := fmt.Sprintf("app_operator_app_info{app=\"%s\",catalog=\"%s\",desired_version=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"batman\",version=\"%s\"} 1",
 			app.Spec.Name,
 			app.Spec.Catalog,
+			app.Status.Version,
 			app.Name,
 			app.Namespace,
 			app.Status.Release.Status,

--- a/service/collector/app.go
+++ b/service/collector/app.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ var (
 			labelStatus,
 			labelTeam,
 			labelVersion,
+			labelVersionMismatch,
 			labelCatalog,
 			labelApp,
 		},
@@ -132,6 +134,7 @@ func (a *App) collectAppStatus(ctx context.Context, ch chan<- prometheus.Metric)
 			team,
 			// Getting version from spec, not status since the version in the spec is the desired version.
 			app.Spec.Version,
+			strconv.FormatBool(app.Spec.Version == app.Status.Version),
 			app.Spec.Catalog,
 			app.Spec.Name,
 		)

--- a/service/collector/app.go
+++ b/service/collector/app.go
@@ -23,6 +23,7 @@ var (
 		[]string{
 			labelName,
 			labelNamespace,
+			labelDesiredVersion,
 			labelStatus,
 			labelTeam,
 			labelVersion,
@@ -126,6 +127,7 @@ func (a *App) collectAppStatus(ctx context.Context, ch chan<- prometheus.Metric)
 			gaugeValue,
 			app.Name,
 			app.Namespace,
+			app.Status.Version,
 			app.Status.Release.Status,
 			team,
 			// Getting version from spec, not status since the version in the spec is the desired version.

--- a/service/collector/app.go
+++ b/service/collector/app.go
@@ -24,7 +24,7 @@ var (
 		[]string{
 			labelName,
 			labelNamespace,
-			labelDesiredVersion,
+			labelDeployedVersion,
 			labelStatus,
 			labelTeam,
 			labelVersion,

--- a/service/collector/app.go
+++ b/service/collector/app.go
@@ -134,7 +134,7 @@ func (a *App) collectAppStatus(ctx context.Context, ch chan<- prometheus.Metric)
 			team,
 			// Getting version from spec, not status since the version in the spec is the desired version.
 			app.Spec.Version,
-			strconv.FormatBool(app.Spec.Version == app.Status.Version),
+			strconv.FormatBool(app.Spec.Version != app.Status.Version),
 			app.Spec.Catalog,
 			app.Spec.Name,
 		)

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -6,12 +6,13 @@ const (
 )
 
 const (
-	labelApp            = "app"
-	labelCatalog        = "catalog"
-	labelDesiredVersion = "desired_version"
-	labelName           = "name"
-	labelNamespace      = "namespace"
-	labelStatus         = "status"
-	labelTeam           = "team"
-	labelVersion        = "version"
+	labelApp             = "app"
+	labelCatalog         = "catalog"
+	labelDesiredVersion  = "desired_version"
+	labelName            = "name"
+	labelNamespace       = "namespace"
+	labelStatus          = "status"
+	labelTeam            = "team"
+	labelVersion         = "version"
+	labelVersionMismatch = "version_mismatch"
 )

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -6,11 +6,12 @@ const (
 )
 
 const (
-	labelApp       = "app"
-	labelCatalog   = "catalog"
-	labelName      = "name"
-	labelNamespace = "namespace"
-	labelStatus    = "status"
-	labelTeam      = "team"
-	labelVersion   = "version"
+	labelApp            = "app"
+	labelCatalog        = "catalog"
+	labelDesiredVersion = "desired_version"
+	labelName           = "name"
+	labelNamespace      = "namespace"
+	labelStatus         = "status"
+	labelTeam           = "team"
+	labelVersion        = "version"
 )

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -8,7 +8,7 @@ const (
 const (
 	labelApp             = "app"
 	labelCatalog         = "catalog"
-	labelDesiredVersion  = "desired_version"
+	labelDeployedVersion = "deployed_version"
 	labelName            = "name"
 	labelNamespace       = "namespace"
 	labelStatus          = "status"


### PR DESCRIPTION
Toward #17617

I added `version_mismatch`, `deployed_version` labels for templating new alerts.

```
app_operator_app_info{app="app-checker", catalog="control-plane", cluster_id="ginger", cluster_type="management_cluster", installation="ginger", instance="100.64.74.64:8000", job="ginger-prometheus/app-exporter-ginger/0", name="app-checker", namespace="default", node="ip-10-0-5-70.eu-west-1.compute.internal", pod="app-exporter-unique-7dfd7c9bc4-wbwpr", provider="aws", role="worker", team="batman", version="0.1.0", version_mismatch="true"}
```

## Checklist

- [x] Update changelog in CHANGELOG.md.
