### PR TITLE
Add halo to cabbage to retired teams mapping plus todo issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `apiextensions-application` instead of `apiextensions` for CRDs to remove
 CAPI dependency.
 
+### Fixed
+
+- Add `halo` to `cabbage` to retired teams mapping.
+
 ## [0.10.0] - 2021-11-12
 
 ### Changed

--- a/helm/app-exporter/templates/configmap.yaml
+++ b/helm/app-exporter/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
       collector:
         apps:
           defaultTeam: "honeybadger"
+          # TODO Remove once old releases are archived https://github.com/giantswarm/giantswarm/issues/20027
           retiredTeams: |
             batman: "honeybadger"
             biscuit: "honeybadger"

--- a/helm/app-exporter/templates/configmap.yaml
+++ b/helm/app-exporter/templates/configmap.yaml
@@ -23,6 +23,7 @@ data:
             biscuit: "honeybadger"
             celestial: "phoenix"
             firecracker: "phoenix"
+            halo: "cabbage"
             ludacris: "honeybadger"
         provider:
           kind: '{{ .Values.provider.kind }}'


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/giantswarm/issues/19760

- Add missing mapping from halo to cabbage for cert-manager
- Link to TODO issue to remove mapping when old releases are archived https://github.com/giantswarm/giantswarm/issues/20027