### PR TITLE
Add mapping of apps to teams when annotation is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add manual mapping of apps to teams for alert routing when team annotation
+in Chart.yaml is missing.
+
 ## [0.11.0] - 2021-12-15
 
 ## Changed

--- a/flag/service/collector/apps/apps.go
+++ b/flag/service/collector/apps/apps.go
@@ -1,6 +1,7 @@
 package apps
 
 type Apps struct {
-	DefaultTeam  string
-	RetiredTeams string
+	AppTeamMappings string
+	DefaultTeam     string
+	RetiredTeams    string
 }

--- a/helm/app-exporter/templates/configmap.yaml
+++ b/helm/app-exporter/templates/configmap.yaml
@@ -17,7 +17,6 @@ data:
       collector:
         apps:
           # appTeamMappings can be used when the team annotation is missing in Chart.yaml.
-          # Make sure you also add the missing annotation.
           appTeamMappings: |
             efk-stack-app: "atlas"
           defaultTeam: "honeybadger"

--- a/helm/app-exporter/templates/configmap.yaml
+++ b/helm/app-exporter/templates/configmap.yaml
@@ -16,6 +16,8 @@ data:
     service:
       collector:
         apps:
+          # appTeamMappings can be used when the team annotation is missing in Chart.yaml.
+          # Make sure you also add the missing annotation.
           appTeamMappings: |
             efk-stack-app: "atlas"
           defaultTeam: "honeybadger"

--- a/helm/app-exporter/templates/configmap.yaml
+++ b/helm/app-exporter/templates/configmap.yaml
@@ -16,7 +16,6 @@ data:
     service:
       collector:
         apps:
-          # appTeamMappings can be used when the team annotation is missing in Chart.yaml.
           appTeamMappings: |
             efk-stack-app: "atlas"
           defaultTeam: "honeybadger"

--- a/helm/app-exporter/templates/configmap.yaml
+++ b/helm/app-exporter/templates/configmap.yaml
@@ -16,6 +16,10 @@ data:
     service:
       collector:
         apps:
+          # appTeamMappings can be used when the team annotation is missing in Chart.yaml.
+          # Make sure you also add the missing annotation.
+          appTeamMappings: |
+            efk-stack-app: "atlas"
           defaultTeam: "honeybadger"
           # TODO Remove once old releases are archived https://github.com/giantswarm/giantswarm/issues/20027
           retiredTeams: |

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func mainE(ctx context.Context) error {
 
 	daemonCommand := newCommand.DaemonCommand().CobraCommand()
 
+	daemonCommand.PersistentFlags().String(f.Service.Collector.Apps.AppTeamMappings, "", "The mapping of retired teams to new teams for alerting.")
 	daemonCommand.PersistentFlags().String(f.Service.Collector.Apps.DefaultTeam, "honeybadger", "The default team for alerting.")
 	daemonCommand.PersistentFlags().String(f.Service.Collector.Apps.RetiredTeams, "", "The mapping of retired teams to new teams for alerting.")
 	daemonCommand.PersistentFlags().String(f.Service.Collector.Provider.Kind, "", "Provider of the management cluster. One of aws, azure, kvm.")

--- a/service/collector/app.go
+++ b/service/collector/app.go
@@ -265,12 +265,17 @@ func (a *App) getTeam(ctx context.Context, app v1alpha1.App) (string, error) {
 	var team string
 	var err error
 
+	if key.AppName(app) == "efk-stack-app" {
+		a.logger.Debugf(ctx, "EFK DEBUG %#v", a.appTeamMappings)
+	}
+
 	// Team has been configured manually via the configmap. This can be used
 	// if the team annotation is missing in Chart.yaml. Make sure the
 	// annotation is added and once its present for all deployments of the
 	// app the mapping can be removed.
 	team = a.appTeamMappings[key.AppName(app)]
 	if team != "" {
+		a.logger.Debugf(ctx, "TEAM %s", team)
 		return team, nil
 	}
 

--- a/service/collector/app.go
+++ b/service/collector/app.go
@@ -265,17 +265,12 @@ func (a *App) getTeam(ctx context.Context, app v1alpha1.App) (string, error) {
 	var team string
 	var err error
 
-	if key.AppName(app) == "efk-stack-app" {
-		a.logger.Debugf(ctx, "EFK DEBUG %#v", a.appTeamMappings)
-	}
-
 	// Team has been configured manually via the configmap. This can be used
 	// if the team annotation is missing in Chart.yaml. Make sure the
 	// annotation is added and once its present for all deployments of the
 	// app the mapping can be removed.
 	team = a.appTeamMappings[key.AppName(app)]
 	if team != "" {
-		a.logger.Debugf(ctx, "TEAM %s", team)
 		return team, nil
 	}
 

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -11,6 +11,7 @@ type SetConfig struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
 
+	AppTeamMappings     map[string]string
 	DefaultTeam         string
 	Provider            string
 	RetiredTeamsMapping map[string]string
@@ -43,6 +44,7 @@ func NewSet(config SetConfig) (*Set, error) {
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 
+			AppTeamMappings:     config.AppTeamMappings,
 			DefaultTeam:         config.DefaultTeam,
 			Provider:            config.Provider,
 			RetiredTeamsMapping: config.RetiredTeamsMapping,

--- a/service/service.go
+++ b/service/service.go
@@ -96,9 +96,17 @@ func New(config Config) (*Service, error) {
 		}
 	}
 
+	var appTeamMappings map[string]string
+	{
+		appTeamMappings, err = newMapping(config.Viper.GetString(config.Flag.Service.Collector.Apps.AppTeamMappings))
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var retiredTeamsMapping map[string]string
 	{
-		retiredTeamsMapping, err = newRetiredTeamsMapping(config.Viper.GetString(config.Flag.Service.Collector.Apps.RetiredTeams))
+		retiredTeamsMapping, err = newMapping(config.Viper.GetString(config.Flag.Service.Collector.Apps.RetiredTeams))
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -110,6 +118,7 @@ func New(config Config) (*Service, error) {
 			K8sClient: k8sClient,
 			Logger:    config.Logger,
 
+			AppTeamMappings:     appTeamMappings,
 			DefaultTeam:         config.Viper.GetString(config.Flag.Service.Collector.Apps.DefaultTeam),
 			Provider:            config.Viper.GetString(config.Flag.Service.Collector.Provider.Kind),
 			RetiredTeamsMapping: retiredTeamsMapping,
@@ -153,7 +162,7 @@ func (s *Service) Boot(ctx context.Context) {
 	})
 }
 
-func newRetiredTeamsMapping(input string) (map[string]string, error) {
+func newMapping(input string) (map[string]string, error) {
 	teams := map[string]string{}
 	err := yaml.Unmarshal([]byte(input), &teams)
 	if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
@@ -163,11 +164,15 @@ func (s *Service) Boot(ctx context.Context) {
 }
 
 func newMapping(input string) (map[string]string, error) {
+	fmt.Printf("INPUT\n%s", input)
+
 	mapping := map[string]string{}
 	err := yaml.Unmarshal([]byte(input), &mapping)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
+
+	fmt.Printf("MAPPING\n%s", mapping)
 
 	return mapping, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -163,11 +163,11 @@ func (s *Service) Boot(ctx context.Context) {
 }
 
 func newMapping(input string) (map[string]string, error) {
-	teams := map[string]string{}
-	err := yaml.Unmarshal([]byte(input), &teams)
+	mapping := map[string]string{}
+	err := yaml.Unmarshal([]byte(input), &mapping)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	return teams, nil
+	return mapping, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -4,7 +4,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
@@ -164,15 +163,11 @@ func (s *Service) Boot(ctx context.Context) {
 }
 
 func newMapping(input string) (map[string]string, error) {
-	fmt.Printf("INPUT\n%s", input)
-
 	mapping := map[string]string{}
 	err := yaml.Unmarshal([]byte(input), &mapping)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-
-	fmt.Printf("MAPPING\n%s", mapping)
 
 	return mapping, nil
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/639

We want to route EFK to Atlas but the team annotation was missing. This adds a mapping via the app-exporter configmap.

Once all app CRs in use have the annotation we can remove this but there may be other apps with the same issue.

## Checklist

- [x] Update changelog in CHANGELOG.md.
