### PR TITLE
Set release status to not-installed when its empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set release status to `not-installed` when it is empty string.
+
 ## [0.12.0] - 2022-01-05
 
 ### Added

--- a/service/collector/app.go
+++ b/service/collector/app.go
@@ -167,6 +167,11 @@ func (a *App) collectAppStatus(ctx context.Context, ch chan<- prometheus.Metric)
 		latestVersion := latestAppVersions[fmt.Sprintf("%s-%s", key.CatalogName(app), key.AppName(app))]
 		upgradeAvailable := latestVersion != "" && latestVersion != appSpecVersion
 
+		releaseStatus := app.Status.Release.Status
+		if releaseStatus == "" {
+			releaseStatus = notInstalledStatus
+		}
+
 		ch <- prometheus.MustNewConstMetric(
 			appDesc,
 			prometheus.GaugeValue,
@@ -178,7 +183,7 @@ func (a *App) collectAppStatus(ctx context.Context, ch chan<- prometheus.Metric)
 			latestVersion,
 			app.Name,
 			app.Namespace,
-			app.Status.Release.Status,
+			releaseStatus,
 			team,
 			strconv.FormatBool(upgradeAvailable),
 			// Getting version from spec, not status since the version in the spec is the desired version.

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -1,8 +1,9 @@
 package collector
 
 const (
-	gaugeValue float64 = 1
-	namespace  string  = "app_operator"
+	gaugeValue         float64 = 1
+	namespace          string  = "app_operator"
+	notInstalledStatus string  = "not-installed"
 )
 
 const (


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20379

If all workload cluster apps fail to be installed we should only page honeybadger. However prometheus rules expect the status to be `not-installed` but when its empty string other teams are paged. 

This fix ensures the status is `not-installed` so the [WorkloadClusterAppNotInstalled](https://github.com/giantswarm/prometheus-rules/blob/82ff8fd8969ad27fd0959c7b945e839df5581158/helm/prometheus-rules/templates/alerting-rules/app.rules.yml#L209-L213) rule works correctly.

## Checklist

- [x] Update changelog in CHANGELOG.md.
