### PR TITLE
Adding label indicating missing cluster label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `cluster_missing` label to the metric for detecting org-namespace App CRs without `giantswarm.io/cluster` Kubernetes label.
+
 ## [0.12.1] - 2022-01-24
 
 ### Fixed

--- a/service/collector/app.go
+++ b/service/collector/app.go
@@ -30,6 +30,7 @@ var (
 			labelApp,
 			labelAppVersion,
 			labelCatalog,
+			labelClusterMissing,
 			labelDeployedVersion,
 			labelLatestVersion,
 			labelName,
@@ -162,6 +163,11 @@ func (a *App) collectAppStatus(ctx context.Context, ch chan<- prometheus.Metric)
 		// we can get rid of this trimming.
 		appSpecVersion := key.Version(app)
 
+		// missingClusterLabel returns "true" if `giantswarm.io/cluster` label is missing
+		// on the org-namespaced app. It returns "false" in other cases, this including
+		// cluster-namespaced app.
+		clusterMissing := key.IsInOrgNamespace(app) && key.ClusterLabel(app) == ""
+
 		// For optional apps in public catalogs we check if an upgrade
 		// is available.
 		latestVersion := latestAppVersions[fmt.Sprintf("%s-%s", key.CatalogName(app), key.AppName(app))]
@@ -179,6 +185,7 @@ func (a *App) collectAppStatus(ctx context.Context, ch chan<- prometheus.Metric)
 			app.Spec.Name,
 			appVersion(app),
 			app.Spec.Catalog,
+			strconv.FormatBool(clusterMissing),
 			app.Status.Version,
 			latestVersion,
 			app.Name,

--- a/service/collector/app.go
+++ b/service/collector/app.go
@@ -163,9 +163,8 @@ func (a *App) collectAppStatus(ctx context.Context, ch chan<- prometheus.Metric)
 		// we can get rid of this trimming.
 		appSpecVersion := key.Version(app)
 
-		// missingClusterLabel returns "true" if `giantswarm.io/cluster` label is missing
-		// on the org-namespaced app. It returns "false" in other cases, this including
-		// cluster-namespaced app.
+		// clusterMissing is true if `giantswarm.io/cluster` label is missing
+		// on the org-namespaced app. Otherwise it's false.
 		clusterMissing := key.IsInOrgNamespace(app) && key.ClusterLabel(app) == ""
 
 		// For optional apps in public catalogs we check if an upgrade

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -10,6 +10,7 @@ const (
 	labelApp              = "app"
 	labelAppVersion       = "app_version"
 	labelCatalog          = "catalog"
+	labelClusterMissing   = "cluster_mising"
 	labelDeployedVersion  = "deployed_version"
 	labelLatestVersion    = "latest_version"
 	labelName             = "name"

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -10,7 +10,7 @@ const (
 	labelApp              = "app"
 	labelAppVersion       = "app_version"
 	labelCatalog          = "catalog"
-	labelClusterMissing   = "cluster_mising"
+	labelClusterMissing   = "cluster_missing"
 	labelDeployedVersion  = "deployed_version"
 	labelLatestVersion    = "latest_version"
 	labelName             = "name"

--- a/tests/ats/metrics_test.go
+++ b/tests/ats/metrics_test.go
@@ -136,10 +136,11 @@ func TestMetrics(t *testing.T) {
 			appVersion = app.Status.AppVersion
 		}
 
-		expectedAppMetric := fmt.Sprintf("app_operator_app_info{app=\"%s\",app_version=\"%s\",catalog=\"%s\",deployed_version=\"%s\",latest_version=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"honeybadger\",upgrade_available=\"%s\",version=\"%s\",version_mismatch=\"%s\"} 1",
+		expectedAppMetric := fmt.Sprintf("app_operator_app_info{app=\"%s\",app_version=\"%s\",catalog=\"%s\",cluster_missing=\"%s\",deployed_version=\"%s\",latest_version=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"honeybadger\",upgrade_available=\"%s\",version=\"%s\",version_mismatch=\"%s\"} 1",
 			app.Spec.Name,
 			appVersion,
 			app.Spec.Catalog,
+			"false",
 			app.Status.Version, // deployed_version
 			"",                 // latest_version is empty
 			app.Name,


### PR DESCRIPTION
## Description

This PR adds an indicator for missing `giantswarm.io/cluster` labels. In general, assuming validation logic in the admission controller works as expected, this should never be set to `true`. But, just in case some apps slip pass by, having extra label on metrics is a good fail safe.

Towards: https://github.com/giantswarm/giantswarm/issues/20536

## Checklist

- [x] Update changelog in CHANGELOG.md.
