### PR TITLE
Fix versions normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Normalize all the versions the exporter works with.
 
-### Changed
-
-- Change how exporter fetches the ACE for a given App CR.
-
 ## [0.13.0] - 2022-01-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Normalize all the versions the exporter works with.
+
+### Changed
+
+- Change how exporter fetches the ACE for a given App CR.
+
 ## [0.13.0] - 2022-01-28
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/giantswarm/microkit v1.0.0
 	github.com/giantswarm/micrologger v0.6.0
 	github.com/giantswarm/operatorkit/v6 v6.1.0
+	github.com/google/go-cmp v0.5.7
 	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/viper v1.10.1
 	k8s.io/apimachinery v0.21.4

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -1,0 +1,9 @@
+package key
+
+import "strings"
+
+// formatVersion normalizes version representation by removing `v` prefix.
+// It matters for customers Catalogs, ACEs and apps created out of them.
+func FormatVersion(input string) string {
+	return strings.TrimPrefix(input, "v")
+}

--- a/service/collector/app_test.go
+++ b/service/collector/app_test.go
@@ -1,10 +1,40 @@
 package collector
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
+	"github.com/giantswarm/k8sclient/v6/pkg/k8sclienttest"
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
+	"github.com/giantswarm/k8smetadata/pkg/label"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
+	prometheustest "github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+// fakeCollector implements prometheus.Collector interface and
+// is wrapper for the App that implements exporterkit interface
+type fakeCollector struct {
+	app *App
+}
+
+func (fc fakeCollector) Collect(ch chan<- prometheus.Metric) {
+	_ = fc.app.Collect(ch)
+}
+
+func (fc fakeCollector) Describe(ch chan<- *prometheus.Desc) {
+	_ = fc.app.Describe(ch)
+}
 
 func Test_convertToTime(t *testing.T) {
 	expectedTime, err := time.Parse(time.RFC3339, "2019-12-31T23:59:59Z")
@@ -51,4 +81,507 @@ func Test_convertToTime(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_collectAppStatus(t *testing.T) {
+	tests := []struct {
+		name                 string
+		apps                 []*v1alpha1.App
+		catalogs             []*v1alpha1.Catalog
+		catalogsEntries      []*v1alpha1.AppCatalogEntry
+		expectedMetrics      string
+		expectedMetricsCount int
+	}{
+		{
+			name: "flawless",
+			apps: []*v1alpha1.App{
+				newApp("hello-world-app", "giantswarm", "hello-world", "0.3.0", "", ""),
+				newApp("example", "customer", "default", "1.0.0", "", ""),
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newCatalog("giantswarm", "default"),
+				newCatalog("customer", "default"),
+			},
+			catalogsEntries: []*v1alpha1.AppCatalogEntry{
+				newACE("hello-world-app", "giantswarm", "default", "0.3.0", "", "", true),
+				newACE("example", "customer", "default", "1.0.0", "", "", true),
+			},
+			expectedMetrics:      "testdata/expected.1",
+			expectedMetricsCount: 2,
+		},
+		{
+			name: "flawless with v* versions",
+			apps: []*v1alpha1.App{
+				newApp("hello-world-app", "giantswarm", "hello-world", "v0.3.0", "", ""),
+				newApp("example", "customer", "default", "v1.0.0", "", ""),
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newCatalog("giantswarm", "default"),
+				newCatalog("customer", "default"),
+			},
+			catalogsEntries: []*v1alpha1.AppCatalogEntry{
+				newACE("hello-world-app", "giantswarm", "default", "v0.3.0", "", "", true),
+				newACE("example", "customer", "default", "v1.0.0", "", "", true),
+			},
+			expectedMetrics:      "testdata/expected.1",
+			expectedMetricsCount: 2,
+		},
+		// It is RECOMMENDED to use mixed versions in the next tests
+		{
+			name: "app pending update",
+			apps: []*v1alpha1.App{
+				newApp("hello-world-app", "giantswarm", "hello-world", "0.3.0", "", ""),
+				newApp("example", "customer", "default", "v1.0.0", "v0.9.0", ""),
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newCatalog("giantswarm", "default"),
+				newCatalog("customer", "default"),
+			},
+			catalogsEntries: []*v1alpha1.AppCatalogEntry{
+				newACE("hello-world-app", "giantswarm", "default", "0.3.0", "", "", true),
+				newACE("example", "customer", "default", "v1.0.0", "", "", true),
+			},
+			expectedMetrics:      "testdata/expected.2",
+			expectedMetricsCount: 2,
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
+			var err error
+
+			gsObj := make([]runtime.Object, 0)
+			for _, ct := range tc.catalogs {
+				gsObj = append(gsObj, ct)
+			}
+
+			for _, cte := range tc.catalogsEntries {
+				gsObj = append(gsObj, cte)
+			}
+
+			for _, app := range tc.apps {
+				gsObj = append(gsObj, app)
+			}
+
+			var k8sClientFake *k8sclienttest.Clients
+			{
+				schemeBuilder := runtime.SchemeBuilder{
+					v1alpha1.AddToScheme,
+				}
+
+				err = schemeBuilder.AddToScheme(scheme.Scheme)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				k8sClientFake = k8sclienttest.NewClients(k8sclienttest.ClientsConfig{
+					CtrlClient: clientfake.NewClientBuilder().
+						WithScheme(scheme.Scheme).
+						WithRuntimeObjects(gsObj...).
+						Build(),
+				})
+			}
+
+			appConfig := AppConfig{
+				K8sClient: k8sClientFake,
+				Logger:    microloggertest.New(),
+
+				DefaultTeam:         "honeybadger",
+				Provider:            "aws",
+				RetiredTeamsMapping: map[string]string{},
+			}
+
+			app, err := NewApp(appConfig)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			fakeColl := fakeCollector{
+				app: app,
+			}
+			num := prometheustest.CollectAndCount(
+				fakeColl,
+				prometheus.BuildFQName(namespace, "app", "info"),
+			)
+			if num != tc.expectedMetricsCount {
+				t.Errorf("expected %d metrics to collect, got %d", tc.expectedMetricsCount, num)
+			}
+
+			expected, err := os.Open(tc.expectedMetrics)
+			if err != nil {
+				panic(err)
+			}
+			defer expected.Close()
+
+			err = prometheustest.CollectAndCompare(
+				fakeColl,
+				expected,
+				prometheus.BuildFQName(namespace, "app", "info"),
+			)
+			if err != nil {
+				t.Errorf("unexpected collecting result:\n %s", err)
+			}
+		})
+	}
+}
+
+func Test_getLatestAppVersions(t *testing.T) {
+	tests := []struct {
+		name             string
+		catalogs         []*v1alpha1.Catalog
+		catalogsEntries  []*v1alpha1.AppCatalogEntry
+		expectedVersions map[string]string
+	}{
+		{
+			name: "flawless",
+			catalogs: []*v1alpha1.Catalog{
+				newCatalog("giantswarm", "default"),
+				newCatalog("customer", "default"),
+			},
+			catalogsEntries: []*v1alpha1.AppCatalogEntry{
+				newACE("hello-world-app", "giantswarm", "default", "0.3.0", "", "", true),
+				newACE("hello-world-app", "giantswarm", "default", "0.2.0", "", "", false),
+				newACE("example", "customer", "default", "1.0.0", "", "", true),
+				newACE("example", "customer", "default", "0.2.0", "", "", false),
+				newACE("example", "customer", "default", "0.1.0", "", "", false),
+			},
+			expectedVersions: map[string]string{
+				"customer-example":           "1.0.0",
+				"giantswarm-hello-world-app": "0.3.0",
+			},
+		},
+		{
+			name: "flawless with v* versions",
+			catalogs: []*v1alpha1.Catalog{
+				newCatalog("giantswarm", "default"),
+				newCatalog("customer", "default"),
+			},
+			catalogsEntries: []*v1alpha1.AppCatalogEntry{
+				newACE("hello-world-app", "giantswarm", "default", "0.3.0", "", "", true),
+				newACE("hello-world-app", "giantswarm", "default", "0.2.0", "", "", false),
+				newACE("example", "customer", "default", "v1.0.0", "", "", true),
+				newACE("example", "customer", "default", "v0.2.0", "", "", false),
+				newACE("example", "customer", "default", "v0.1.0", "", "", false),
+			},
+			expectedVersions: map[string]string{
+				"customer-example":           "1.0.0",
+				"giantswarm-hello-world-app": "0.3.0",
+			},
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
+			var err error
+
+			gsObj := make([]runtime.Object, 0)
+			for _, ct := range tc.catalogs {
+				gsObj = append(gsObj, ct)
+			}
+
+			for _, cte := range tc.catalogsEntries {
+				gsObj = append(gsObj, cte)
+			}
+
+			var k8sClientFake *k8sclienttest.Clients
+			{
+				schemeBuilder := runtime.SchemeBuilder{
+					v1alpha1.AddToScheme,
+				}
+
+				err = schemeBuilder.AddToScheme(scheme.Scheme)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				k8sClientFake = k8sclienttest.NewClients(k8sclienttest.ClientsConfig{
+					CtrlClient: clientfake.NewClientBuilder().
+						WithScheme(scheme.Scheme).
+						WithRuntimeObjects(gsObj...).
+						Build(),
+				})
+			}
+
+			appConfig := AppConfig{
+				K8sClient: k8sClientFake,
+				Logger:    microloggertest.New(),
+
+				DefaultTeam:         "honeybadger",
+				Provider:            "aws",
+				RetiredTeamsMapping: map[string]string{},
+			}
+
+			app, err := NewApp(appConfig)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			latestAppVersions, err := app.getLatestAppVersions(context.TODO())
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			if !reflect.DeepEqual(latestAppVersions, tc.expectedVersions) {
+				t.Fatalf("want matching resources \n %s", cmp.Diff(latestAppVersions, tc.expectedVersions))
+			}
+		})
+	}
+}
+
+func Test_getTeamMappings(t *testing.T) {
+	tests := []struct {
+		name                 string
+		apps                 []v1alpha1.App
+		catalogs             []*v1alpha1.Catalog
+		catalogsEntries      []*v1alpha1.AppCatalogEntry
+		expectedTeamMappings map[string]string
+		retiredTeamsMapping  map[string]string
+	}{
+		{
+			name: "flawless",
+			apps: []v1alpha1.App{
+				*newApp("hello-world-app", "giantswarm", "hello-world", "0.2.0", "", ""),
+				*newApp("example", "customer", "default", "1.0.0", "", ""),
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newCatalog("giantswarm", "default"),
+				newCatalog("customer", "default"),
+			},
+			catalogsEntries: []*v1alpha1.AppCatalogEntry{
+				newACE(
+					"hello-world-app", "giantswarm", "default", "0.3.0",
+					"[{'team':'honeybadger','catalog':'giantswarm'}]", "", true,
+				),
+				newACE(
+					"hello-world-app", "giantswarm", "default", "0.2.0",
+					"[{'team':'honeybadger','catalog':'giantswarm'}]", "", false,
+				),
+				newACE("example", "customer", "default", "1.0.0", "", "customer-team", true),
+				newACE("example", "customer", "default", "0.2.0", "", "customer-team", false),
+				newACE("example", "customer", "default", "0.1.0", "", "customer-team", false),
+			},
+			expectedTeamMappings: map[string]string{
+				"customer-example-1.0.0":           "customer-team",
+				"giantswarm-hello-world-app-0.2.0": "honeybadger",
+			},
+			retiredTeamsMapping: map[string]string{},
+		},
+		{
+			name: "flawless with v* versions",
+			apps: []v1alpha1.App{
+				*newApp("hello-world-app", "giantswarm", "hello-world", "0.2.0", "", ""),
+				*newApp("example", "customer", "default", "v1.0.0", "", ""),
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newCatalog("giantswarm", "default"),
+				newCatalog("customer", "default"),
+			},
+			catalogsEntries: []*v1alpha1.AppCatalogEntry{
+				newACE(
+					"hello-world-app", "giantswarm", "default", "0.3.0",
+					"[{'team':'honeybadger','catalog':'giantswarm'}]", "", true,
+				),
+				newACE(
+					"hello-world-app", "giantswarm", "default", "0.2.0",
+					"[{'team':'honeybadger','catalog':'giantswarm'}]", "", false,
+				),
+				newACE("example", "customer", "default", "v1.0.0", "", "customer-team", true),
+				newACE("example", "customer", "default", "v0.2.0", "", "customer-team", false),
+				newACE("example", "customer", "default", "v0.1.0", "", "customer-team", false),
+			},
+			expectedTeamMappings: map[string]string{
+				"customer-example-1.0.0":           "customer-team",
+				"giantswarm-hello-world-app-0.2.0": "honeybadger",
+			},
+			retiredTeamsMapping: map[string]string{},
+		},
+		{
+			name: "flawless with team mappings",
+			apps: []v1alpha1.App{
+				*newApp("hello-world-app", "giantswarm", "hello-world", "0.3.0", "", ""),
+				*newApp("example", "customer", "default", "v1.0.0", "", ""),
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newCatalog("giantswarm", "default"),
+				newCatalog("customer", "default"),
+			},
+			catalogsEntries: []*v1alpha1.AppCatalogEntry{
+				newACE(
+					"hello-world-app",
+					"giantswarm",
+					"default",
+					"0.3.0",
+					"[{'team':'batman','catalog':'giantswarm'}]",
+					"",
+					true,
+				),
+				newACE(
+					"example",
+					"customer",
+					"default",
+					"v1.0.0",
+					"",
+					"customer-team",
+					true,
+				),
+			},
+			expectedTeamMappings: map[string]string{
+				"customer-example-1.0.0":           "customer-team",
+				"giantswarm-hello-world-app-0.3.0": "honeybadger",
+			},
+			retiredTeamsMapping: map[string]string{
+				"batman": "honeybadger",
+			},
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
+			var err error
+
+			gsObj := make([]runtime.Object, 0)
+			for _, ct := range tc.catalogs {
+				gsObj = append(gsObj, ct)
+			}
+
+			for _, cte := range tc.catalogsEntries {
+				gsObj = append(gsObj, cte)
+			}
+
+			var k8sClientFake *k8sclienttest.Clients
+			{
+				schemeBuilder := runtime.SchemeBuilder{
+					v1alpha1.AddToScheme,
+				}
+
+				err = schemeBuilder.AddToScheme(scheme.Scheme)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				k8sClientFake = k8sclienttest.NewClients(k8sclienttest.ClientsConfig{
+					CtrlClient: clientfake.NewClientBuilder().
+						WithScheme(scheme.Scheme).
+						WithRuntimeObjects(gsObj...).
+						Build(),
+				})
+			}
+
+			appConfig := AppConfig{
+				K8sClient: k8sClientFake,
+				Logger:    microloggertest.New(),
+
+				DefaultTeam:         "honeybadger",
+				Provider:            "aws",
+				RetiredTeamsMapping: tc.retiredTeamsMapping,
+			}
+
+			app, err := NewApp(appConfig)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			teamsMappings, err := app.getTeamMappings(context.TODO(), tc.apps)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			if !reflect.DeepEqual(teamsMappings, tc.expectedTeamMappings) {
+				t.Fatalf("want matching resources \n %s", cmp.Diff(teamsMappings, tc.expectedTeamMappings))
+			}
+		})
+	}
+}
+
+func newACE(app, catalog, namespace, version, owners, team string, latest bool) *v1alpha1.AppCatalogEntry {
+	ace := v1alpha1.AppCatalogEntry{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AppCatalogEntry",
+			APIVersion: "application.giantswarm.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"application.giantswarm.io/owners": "[{team:test,catalog:giantswarm}]",
+			},
+			Labels: map[string]string{
+				label.CatalogName:          catalog,
+				label.AppKubernetesName:    app,
+				label.AppKubernetesVersion: version,
+			},
+			Name:      fmt.Sprintf("%s-%s-%s", catalog, app, version),
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.AppCatalogEntrySpec{
+			AppName: app,
+			Catalog: v1alpha1.AppCatalogEntrySpecCatalog{
+				Name: catalog,
+			},
+			Version: version,
+		},
+	}
+
+	if latest {
+		ace.ObjectMeta.Labels["latest"] = "true"
+	}
+
+	if owners != "" {
+		ace.ObjectMeta.Annotations[annotation.AppOwners] = owners
+	}
+
+	if team != "" {
+		ace.ObjectMeta.Annotations[annotation.AppTeam] = team
+	}
+
+	return &ace
+}
+
+func newApp(name, catalog, namespace, version, statusVersion, statusRelease string) *v1alpha1.App {
+	if statusVersion == "" {
+		statusVersion = version
+	}
+
+	if statusRelease == "" {
+		statusRelease = "deployed"
+	}
+
+	app := v1alpha1.App{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "App",
+			APIVersion: "application.giantswarm.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    map[string]string{},
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.AppSpec{
+			Name:      name,
+			Namespace: namespace,
+			Catalog:   catalog,
+			Version:   version,
+		},
+		Status: v1alpha1.AppStatus{
+			Release: v1alpha1.AppStatusRelease{
+				Status: statusRelease,
+			},
+			Version: statusVersion,
+		},
+	}
+
+	return &app
+}
+
+func newCatalog(name, namespace string) *v1alpha1.Catalog {
+	catalog := v1alpha1.Catalog{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Catalog",
+			APIVersion: "application.giantswarm.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				label.CatalogVisibility: "public",
+			},
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	return &catalog
 }

--- a/service/collector/app_test.go
+++ b/service/collector/app_test.go
@@ -388,7 +388,7 @@ func Test_getTeamMappings(t *testing.T) {
 				newACE("example", "customer", "default", "v0.1.0", "", "customer-team", false),
 			},
 			expectedTeamMappings: map[string]string{
-				"customer-example-1.0.0":           "customer-team",
+				"customer-example-1.0.0":           "",
 				"giantswarm-hello-world-app-0.2.0": "honeybadger",
 			},
 			retiredTeamsMapping: map[string]string{},
@@ -424,7 +424,7 @@ func Test_getTeamMappings(t *testing.T) {
 				),
 			},
 			expectedTeamMappings: map[string]string{
-				"customer-example-1.0.0":           "customer-team",
+				"customer-example-1.0.0":           "",
 				"giantswarm-hello-world-app-0.3.0": "honeybadger",
 			},
 			retiredTeamsMapping: map[string]string{

--- a/service/collector/app_test.go
+++ b/service/collector/app_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // fakeCollector implements prometheus.Collector interface and
-// is wrapper for the App that implements exporterkit interface
+// is wrapper for the App that implements exporterkit.Collector
 type fakeCollector struct {
 	app *App
 }

--- a/service/collector/testdata/expected.1
+++ b/service/collector/testdata/expected.1
@@ -1,0 +1,4 @@
+# HELP app_operator_app_info Managed apps status.
+# TYPE app_operator_app_info gauge
+app_operator_app_info{app="example",app_version="",catalog="customer",cluster_missing="false",deployed_version="1.0.0",latest_version="1.0.0",name="example",namespace="default",status="deployed",team="honeybadger",upgrade_available="false",version="1.0.0",version_mismatch="false"} 1
+app_operator_app_info{app="hello-world-app",app_version="",catalog="giantswarm",cluster_missing="false",deployed_version="0.3.0",latest_version="0.3.0",name="hello-world-app",namespace="hello-world",status="deployed",team="honeybadger",upgrade_available="false",version="0.3.0",version_mismatch="false"} 1

--- a/service/collector/testdata/expected.2
+++ b/service/collector/testdata/expected.2
@@ -1,0 +1,4 @@
+# HELP app_operator_app_info Managed apps status.
+# TYPE app_operator_app_info gauge
+app_operator_app_info{app="example",app_version="",catalog="customer",cluster_missing="false",deployed_version="0.9.0",latest_version="1.0.0",name="example",namespace="default",status="deployed",team="honeybadger",upgrade_available="false",version="1.0.0",version_mismatch="true"} 1
+app_operator_app_info{app="hello-world-app",app_version="",catalog="giantswarm",cluster_missing="false",deployed_version="0.3.0",latest_version="0.3.0",name="hello-world-app",namespace="hello-world",status="deployed",team="honeybadger",upgrade_available="false",version="0.3.0",version_mismatch="false"} 1

--- a/tests/ats/metrics_test.go
+++ b/tests/ats/metrics_test.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/app-exporter/pkg/project"
+
+	expkey "github.com/giantswarm/app-exporter/internal/key"
 )
 
 const (
@@ -133,7 +135,7 @@ func TestMetrics(t *testing.T) {
 		var appVersion string
 
 		if app.Status.AppVersion != app.Status.Version {
-			appVersion = formatVersion(app.Status.AppVersion)
+			appVersion = expkey.FormatVersion(app.Status.AppVersion)
 		}
 
 		expectedAppMetric := fmt.Sprintf("app_operator_app_info{app=\"%s\",app_version=\"%s\",catalog=\"%s\",cluster_missing=\"%s\",deployed_version=\"%s\",latest_version=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"honeybadger\",upgrade_available=\"%s\",version=\"%s\",version_mismatch=\"%s\"} 1",
@@ -141,13 +143,13 @@ func TestMetrics(t *testing.T) {
 			appVersion,
 			app.Spec.Catalog,
 			"false",
-			formatVersion(app.Status.Version), // deployed_version
-			"",                                // latest_version is empty
+			expkey.FormatVersion(app.Status.Version), // deployed_version
+			"",                                       // latest_version is empty
 			app.Name,
 			app.Namespace,
 			app.Status.Release.Status,
-			"false",                         // upgrade_avaiable is false
-			formatVersion(app.Spec.Version), // version is the desired version
+			"false",                                // upgrade_avaiable is false
+			expkey.FormatVersion(app.Spec.Version), // version is the desired version
 			strconv.FormatBool(app.Spec.Version != app.Status.Version))
 
 		logger.Debugf(ctx, "checking for expected app metric\n%s", expectedAppMetric)
@@ -174,12 +176,6 @@ func TestMetrics(t *testing.T) {
 
 		logger.Debugf(ctx, "found expected app-operator metric")
 	}
-}
-
-// formatVersion normalizes version representation by removing `v` prefix.
-// It matters for customers Catalogs, ACEs and apps created out of them.
-func formatVersion(input string) string {
-	return strings.TrimPrefix(input, "v")
 }
 
 func waitForPod(ctx context.Context, k8sClients *k8sclient.Clients) (string, error) {

--- a/tests/ats/metrics_test.go
+++ b/tests/ats/metrics_test.go
@@ -133,7 +133,7 @@ func TestMetrics(t *testing.T) {
 		var appVersion string
 
 		if app.Status.AppVersion != app.Status.Version {
-			appVersion = app.Status.AppVersion
+			appVersion = formatVersion(app.Status.AppVersion)
 		}
 
 		expectedAppMetric := fmt.Sprintf("app_operator_app_info{app=\"%s\",app_version=\"%s\",catalog=\"%s\",cluster_missing=\"%s\",deployed_version=\"%s\",latest_version=\"%s\",name=\"%s\",namespace=\"%s\",status=\"%s\",team=\"honeybadger\",upgrade_available=\"%s\",version=\"%s\",version_mismatch=\"%s\"} 1",
@@ -141,13 +141,13 @@ func TestMetrics(t *testing.T) {
 			appVersion,
 			app.Spec.Catalog,
 			"false",
-			app.Status.Version, // deployed_version
-			"",                 // latest_version is empty
+			formatVersion(app.Status.Version), // deployed_version
+			"",                                // latest_version is empty
 			app.Name,
 			app.Namespace,
 			app.Status.Release.Status,
-			"false",          // upgrade_avaiable is false
-			app.Spec.Version, // version is the desired version
+			"false",                         // upgrade_avaiable is false
+			formatVersion(app.Spec.Version), // version is the desired version
 			strconv.FormatBool(app.Spec.Version != app.Status.Version))
 
 		logger.Debugf(ctx, "checking for expected app metric\n%s", expectedAppMetric)
@@ -174,6 +174,12 @@ func TestMetrics(t *testing.T) {
 
 		logger.Debugf(ctx, "found expected app-operator metric")
 	}
+}
+
+// formatVersion normalizes version representation by removing `v` prefix.
+// It matters for customers Catalogs, ACEs and apps created out of them.
+func formatVersion(input string) string {
+	return strings.TrimPrefix(input, "v")
 }
 
 func waitForPod(ctx context.Context, k8sClients *k8sclient.Clients) (string, error) {


### PR DESCRIPTION
## Description

Towards: https://github.com/giantswarm/giantswarm/issues/21851

Tested on `ghost`.

This PR basically extends version normalization we introduced [here](https://github.com/giantswarm/app-exporter/pull/228) to all the version the exporter works with. The solution we introduced back then works fine for GS catalogs that host apps without the `v` prefix, hence ACEs, and Charts CRs are created without it, so it simply need to be removed from the entrypoint App CR `.spec.version`. 

For the customers catalogs it may be different. When apps hosted there carry the `v` prefix, we create ACEs with the `v` prefix and also put the `v` prefixed versions into Chart CRs upon creation (taking them from `index.yaml`) which are then reflected in the `.status` field of corresponding App CRs. Now, trimming the prefix for `.spev.version` field only, makes exporter think that there is a mismatch between what's deployed and what's requested by the user. See example below.

This is still a workaround, when for example we migrate to OCR registries and start using them for Flux as a source of truth for the versions available for automatic update, then we can drop this normalization.

CRs given:

```yaml
## App CR
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: example
  namespace: demo0
spec:
  catalog: customer
  kubeConfig:
    inCluster: false
  name: example
  namespace: example
  version: v1.0.0
status:
  release:
    status: deployed
  version: v1.0.0
```

```yaml
# ACE
apiVersion: application.giantswarm.io/v1alpha1
kind: AppCatalogEntry
metadata:
  labels:
    app.kubernetes.io/name: example
    app.kubernetes.io/version: v1.0.0
    application.giantswarm.io/catalog: customer
    application.giantswarm.io/catalog-type: "public"
    giantswarm.io/managed-by: app-operator-unique
    latest: "true"
  name: example-customer-v1.0.0
  namespace: default
spec:
  appName: example
  appVersion: ""
  catalog:
    name: customer
    namespace: default
  version: v1.0.0
```

Resultant metric being exported:

```sh
app_operator_app_info{
app="example",
app_version="",
catalog="customer",
cluster_missing="false",
deployed_version="v1.0.0",  # prefix
latest_version="v1.0.0",  # prefix
name="workflow",
namespace="demo0",
status="deployed",
team="honeybadger",
upgrade_available="true",
version="1.0.0",   # no prefix
version_mismatch="true"
} 1
```

After normalization result should be:

```sh
app_operator_app_info{
app="example",
app_version="",
catalog="customer",
cluster_missing="false",
deployed_version="1.0.0",
latest_version="1.0.0",
name="example",
namespace="default",
status="deployed",
team="honeybadger",
upgrade_available="false",
version="1.0.0",
version_mismatch="false"
} 1
```


## Checklist

- [x] Update changelog in CHANGELOG.md.
