### PR TITLE
Ignore missing `app-operator.giantswarm.io/version` labels on CAPI clusters

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,8 +1,4 @@
 # pkg:golang/github.com/hashicorp/consul/api@v1.12.0
-# imported from: github.com/spf13/viper@v1.11.0 (current latest)
-CVE-2022-29153 until=2022-08-01
-CVE-2022-24687 until=2022-08-01
-
 # pkg:golang/github.com/hashicorp/consul/sdk@v0.8.0
 # imported from:
 #  - github.com/giantswarm/exporterkit@v1.0.0
@@ -10,16 +6,16 @@ CVE-2022-24687 until=2022-08-01
 #  - github.com/giantswarm/microendpoint@v1.0.0
 #  - github.com/giantswarm/microkit@v1.0.0
 #  - sigs.k8s.io/cluster-api@v1.0.5
-CVE-2022-29153 until=2022-08-01
-CVE-2022-24687 until=2022-08-01
+CVE-2022-29153 until=2022-12-31
+CVE-2022-24687 until=2022-12-31
 
 # pkg:golang/github.com/kataras/iris/v12@v12.1.8
 # imported from: github.com/giantswarm/operatorkit/v7@v7.0.1
-CVE-2021-23772 until=2022-08-01
+CVE-2021-23772 until=2022-12-31
 
 # pkg:golang/github.com/urfave/negroni@v1.0.0
 # imported from: github.com/giantswarm/operatorkit/v7@v7.0.1
-sonatype-2021-1485 until=2022-08-01
+sonatype-2021-1485 until=2022-12-31
 
 # pkg:golang/github.com/nats-io/jwt@v1.2.2
-CVE-2021-3127 until=2022-08-01
+CVE-2021-3127 until=2022-12-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- Fix skipping app namespaces if the app-operator version was already scraped
+
+### Changed
+
+- Skip collecting app versions for apps in the org-* namespaces as apps in these (typically CAPI cluster) namespaces the `app-operator.giantswarm.io/version` is not mandatory / makes sense
+
 ## [0.16.1] - 2022-07-01
 
 ### Fixes

--- a/service/collector/app_operator.go
+++ b/service/collector/app_operator.go
@@ -3,10 +3,10 @@ package collector
 import (
 	"context"
 	"fmt"
-	"github.com/giantswarm/app/v6/pkg/key"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
+	"github.com/giantswarm/app/v6/pkg/key"
 	"github.com/giantswarm/k8sclient/v6/pkg/k8sclient"
 	"github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"

--- a/service/collector/app_operator.go
+++ b/service/collector/app_operator.go
@@ -142,6 +142,7 @@ func (a *AppOperator) collectAppVersions(ctx context.Context) (map[string]map[st
 			}
 		}
 
+		appNamespaces[app.Namespace] = true
 		appVersions[version] = appNamespaces
 	}
 

--- a/service/collector/app_operator.go
+++ b/service/collector/app_operator.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"fmt"
+	"github.com/giantswarm/app/v6/pkg/key"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
@@ -128,6 +129,12 @@ func (a *AppOperator) collectAppVersions(ctx context.Context) (map[string]map[st
 	}
 
 	for _, app := range apps.Items {
+		// Skip apps that are in `org-*` namespaces (CAPI, `app-operator.giantswarm.io/version` label is not mandatory there)
+		if key.IsInOrgNamespace(app) {
+			a.logger.Debugf(ctx, "Skipping collecting App versions in `org-*` namespaces for app %#q in %#q", app.Name, app.Namespace)
+			continue
+		}
+
 		version := app.Labels[label.AppOperatorVersion]
 		appNamespaces, ok := appVersions[version]
 		if !ok {

--- a/service/collector/app_operator_test.go
+++ b/service/collector/app_operator_test.go
@@ -3,15 +3,14 @@ package collector
 import (
 	"context"
 	"fmt"
-	"github.com/giantswarm/micrologger/microloggertest"
 	"reflect"
 	"testing"
 
-	"github.com/giantswarm/k8smetadata/pkg/label"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/k8sclient/v6/pkg/k8sclienttest"
+	"github.com/giantswarm/k8smetadata/pkg/label"
+	"github.com/giantswarm/micrologger/microloggertest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/service/collector/app_operator_test.go
+++ b/service/collector/app_operator_test.go
@@ -1,0 +1,123 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"github.com/giantswarm/k8smetadata/pkg/label"
+	"github.com/giantswarm/micrologger/microloggertest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
+	"github.com/giantswarm/k8sclient/v6/pkg/k8sclienttest"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_collectAppVersions(t *testing.T) {
+	var tests = []struct {
+		name                string
+		apps                []*v1alpha1.App
+		expectedAppVersions map[string]map[string]bool
+		errorMatcher        func(error) bool
+	}{
+		{
+			name: fmt.Sprintf("case 1: All apps have the %#q label", label.AppOperatorVersion),
+			apps: []*v1alpha1.App{
+				newTestApp("hello-world-1", "abc01", map[string]string{
+					label.AppOperatorVersion: "6.3.0",
+				}),
+				newTestApp("hello-world-2", "xyz01", map[string]string{
+					label.AppOperatorVersion: "5.9.2",
+				}),
+				newTestApp("hello-world-3", "testing", map[string]string{
+					label.AppOperatorVersion: "6.3.0",
+				}),
+			},
+			expectedAppVersions: map[string]map[string]bool{
+				"6.3.0": {
+					"abc01":   true,
+					"testing": true,
+				},
+				"5.9.2": {
+					"xyz01": true,
+				},
+			},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
+			var err error
+
+			gsObj := make([]runtime.Object, 0)
+
+			for _, app := range tc.apps {
+				gsObj = append(gsObj, app)
+			}
+
+			var k8sClientFake *k8sclienttest.Clients
+			{
+				schemeBuilder := runtime.SchemeBuilder{
+					v1alpha1.AddToScheme,
+				}
+
+				err = schemeBuilder.AddToScheme(scheme.Scheme)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				k8sClientFake = k8sclienttest.NewClients(k8sclienttest.ClientsConfig{
+					CtrlClient: clientfake.NewClientBuilder().
+						WithScheme(scheme.Scheme).
+						WithRuntimeObjects(gsObj...).
+						Build(),
+				})
+			}
+
+			appOperator := &AppOperator{
+				k8sClient: k8sClientFake,
+				logger:    microloggertest.New(),
+			}
+
+			appVersions, err := appOperator.collectAppVersions(context.TODO())
+
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(appVersions, tc.expectedAppVersions) {
+				t.Errorf("collectAppVersions() = %v, want %v", appVersions, tc.expectedAppVersions)
+			}
+		})
+	}
+}
+
+func newTestApp(name, namespace string, labels map[string]string) *v1alpha1.App {
+	app := v1alpha1.App{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "App",
+			APIVersion: "application.giantswarm.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    labels,
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.AppSpec{
+			Name:      name,
+			Namespace: namespace,
+			Catalog:   "test-catalog",
+			Version:   "1.0.0",
+		},
+	}
+
+	return &app
+}

--- a/service/collector/app_operator_test.go
+++ b/service/collector/app_operator_test.go
@@ -3,11 +3,12 @@ package collector
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"testing"
+
 	"github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/micrologger/microloggertest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
-	"testing"
 
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/k8sclient/v6/pkg/k8sclienttest"


### PR DESCRIPTION
## Changes

- Fix skipping app namespaces if the app-operator version was already scraped
-  Skip collecting app versions for apps in the org-* namespaces

    The `app-operator.giantswarm.io/version` label is not mandatory there (CAPI clusters)
    so we do not know the version of the app-operator reconciling these apps. We could check
    the app-operator in the same, org namespace but then the validation after that that this
    part does makes little sense as if we were able to get the version than the opp-operator
    obviously does exist.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
