### PR TITLE
Make scrape timeout configurable and set the default to 45s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make scrape timeout configurable and set the default to 45s.
+
 ## [0.16.2] - 2022-09-06
 
 ### Fixes

--- a/helm/app-exporter/templates/service-monitor.yaml
+++ b/helm/app-exporter/templates/service-monitor.yaml
@@ -9,9 +9,7 @@ metadata:
 spec:
   endpoints:
     - port: web
-      {{- if hasPrefix "cn-" .Values.provider.region }}
-      scrapeTimeout: 30s
-      {{- end }}
+      scrapeTimeout: {{ .Values.scrapeTimeout }}
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}

--- a/helm/app-exporter/values.yaml
+++ b/helm/app-exporter/values.yaml
@@ -26,3 +26,8 @@ pod:
 project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"
+
+# Please note scrapeTimeout set here works only if the cluster app-exporter is
+# deployed to supports monitoring.coreos.com/v1 CRs. Otherwise it has no
+# influence over the Prometheus scraping timeout.
+scrapeTimeout: "45s"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23389

- make scrapeTimeout configurable
- use '.Values.scrapeTimeout' in ServiceMonitor
- set default timeout to 45s

## Checklist

- [x] Update changelog in CHANGELOG.md.
