### PR TITLE
helm/values: Reduce scrapeTimeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce scrape timeout to 30s to prevent Prometheus from crashing.
+
 ## [0.17.0] - 2022-10-06
 
 ### Changed

--- a/helm/app-exporter/values.yaml
+++ b/helm/app-exporter/values.yaml
@@ -30,4 +30,4 @@ project:
 # Please note scrapeTimeout set here works only if the cluster app-exporter is
 # deployed to supports monitoring.coreos.com/v1 CRs. Otherwise it has no
 # influence over the Prometheus scraping timeout.
-scrapeTimeout: "45s"
+scrapeTimeout: "30s"


### PR DESCRIPTION
Prometheus crashes when scrapeTimeout is higher than scrapeInterval.

```
level=error ts=2022-10-06T21:35:30.484Z caller=main.go:356 msg="Error loading config (--config.file=/etc/prometheus/config_out/prometheus.env.yaml)" err="parsing YAML file /etc/prometheus/config_out/prometheus.env.yaml: scrape timeout greater than scrape interval for scrape config with job name \"serviceMonitor/giantswarm/app-exporter/0\""
```

We are not defining the scrape interval in Prometheus CRs generated by `prometheus-meta-operator`, so the default scrape interval of 30s gets used. I'm reducing the default scrape timeout to 30s for now to silence the alert, you might want to make the scrape interval configurable and higher than the timeout later.

## Checklist

- [x] Update changelog in CHANGELOG.md.
