### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.35.1
+  architect: giantswarm/architect@4.35.5
 
 workflows:
   build:
@@ -13,41 +13,11 @@ workflows:
             tags:
               only: /^v.*/
 
-      - architect/push-to-docker:
-          context: "architect"
-          name: push-app-exporter-to-docker
-          image: "docker.io/giantswarm/app-exporter"
-          username_envar: "DOCKER_USERNAME"
-          password_envar: "DOCKER_PASSWORD"
+      - architect/push-to-registries:
+          context: architect
+          name: push-to-registries
           requires:
             - go-build
-          # Needed to trigger job also on git tag.
-          filters:
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-docker:
-          context: "architect"
-          name: push-app-exporter-to-quay
-          image: "quay.io/giantswarm/app-exporter"
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
-          requires:
-            - go-build
-          # Needed to trigger job also on git tag.
-          filters:
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-docker:
-          context: "architect"
-          name: push-app-exporter-to-aliyun
-          image: "giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/app-exporter"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          requires:
-            - go-build
-          # Needed to trigger job also on git tag.
           filters:
             tags:
               only: /^v.*/
@@ -60,9 +30,7 @@ workflows:
           chart: "app-exporter"
           persist_chart_archive: true
           requires:
-            - push-app-exporter-to-docker
-            - push-app-exporter-to-quay
-          # Needed to trigger job also on git tag.
+            - push-to-registries
           filters:
             tags:
               only: /^v.*/
@@ -78,8 +46,8 @@ workflows:
           app_name: "app-exporter"
           app_collection_repo: "aws-app-collection"
           requires:
-            - push-app-exporter-to-aliyun
             - push-app-exporter-to-control-plane-catalog
+            - push-to-registries
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,11 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-catalog:
-          context: "architect"
-          name: push-app-exporter-to-control-plane-catalog
-          app_catalog: "control-plane-catalog"
-          app_catalog_test: "control-plane-test-catalog"
-          chart: "app-exporter"
+          context: architect
+          name: push-to-app-catalog
+          app_catalog: control-plane-catalog
+          app_catalog_test: control-plane-test-catalog
+          chart: app-exporter
           persist_chart_archive: true
           requires:
             - push-to-registries
@@ -38,16 +38,15 @@ workflows:
       - architect/run-tests-with-ats:
           name: run-tests-with-ats
           requires:
-            - push-app-exporter-to-control-plane-catalog
+            - push-to-app-catalog
 
       - architect/push-to-app-collection:
           context: architect
           name: push-app-exporter-to-aws-app-collection
-          app_name: "app-exporter"
-          app_collection_repo: "aws-app-collection"
+          app_name: app-exporter
+          app_collection_repo: aws-app-collection
           requires:
-            - push-app-exporter-to-control-plane-catalog
-            - push-to-registries
+            - push-to-app-catalog
           filters:
             branches:
               ignore: /.*/
@@ -57,10 +56,10 @@ workflows:
       - architect/push-to-app-collection:
           context: architect
           name: push-app-exporter-to-azure-app-collection
-          app_name: "app-exporter"
-          app_collection_repo: "azure-app-collection"
+          app_name: app-exporter
+          app_collection_repo: azure-app-collection
           requires:
-            - push-app-exporter-to-control-plane-catalog
+            - push-to-app-catalog
           filters:
             branches:
               ignore: /.*/
@@ -70,10 +69,10 @@ workflows:
       - architect/push-to-app-collection:
           context: architect
           name: push-app-exporter-to-vsphere-app-collection
-          app_name: "app-exporter"
-          app_collection_repo: "vsphere-app-collection"
+          app_name: app-exporter
+          app_collection_repo: vsphere-app-collection
           requires:
-            - push-app-exporter-to-control-plane-catalog
+            - push-to-app-catalog
           filters:
             branches:
               ignore: /.*/
@@ -84,10 +83,10 @@ workflows:
       - architect/push-to-app-collection:
           name: push-to-cloud-director-app-collection
           context: architect
-          app_name: "app-exporter"
-          app_collection_repo: "cloud-director-app-collection"
+          app_name: app-exporter
+          app_collection_repo: cloud-director-app-collection
           requires:
-            - push-app-exporter-to-control-plane-catalog
+            - push-to-app-catalog
           filters:
             branches:
               ignore: /.*/
@@ -97,10 +96,10 @@ workflows:
       - architect/push-to-app-collection:
           context: architect
           name: push-to-capa-app-collection
-          app_name: "app-exporter"
-          app_collection_repo: "capa-app-collection"
+          app_name: app-exporter
+          app_collection_repo: capa-app-collection
           requires:
-            - push-app-exporter-to-control-plane-catalog
+            - push-to-app-catalog
           filters:
             branches:
               ignore: /.*/
@@ -110,10 +109,10 @@ workflows:
       - architect/push-to-app-collection:
           context: architect
           name: push-to-capz-app-collection
-          app_name: "app-exporter"
-          app_collection_repo: "capz-app-collection"
+          app_name: app-exporter
+          app_collection_repo: capz-app-collection
           requires:
-            - push-app-exporter-to-control-plane-catalog
+            - push-to-app-catalog
           filters:
             branches:
               ignore: /.*/
@@ -123,10 +122,10 @@ workflows:
       - architect/push-to-app-collection:
           context: architect
           name: push-to-gcp-app-collection
-          app_name: "app-exporter"
-          app_collection_repo: "gcp-app-collection"
+          app_name: app-exporter
+          app_collection_repo: gcp-app-collection
           requires:
-            - push-app-exporter-to-control-plane-catalog
+            - push-to-app-catalog
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

Context: [announcement in `#news-dev` on Slack](https://gigantic.slack.com/archives/C04TGHDEF/p1701170353580999)

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- [x] Assign this PR to yourself
- [x] Double-check the job dependecies (`requires`)
- [x] Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- [ ] Update the changelog if you think this deserves a mention
- [ ] Approve and merge this PR once it's ready. No need to wait for the author in this case.

Please get this done until **December 5**, so that we can move on with the next migration steps. Thank you!