### PR TITLE
Ingore patch suffix from the app operator deployment when checking fo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ingore patch suffix from the app operator deployment when checking for versions.
+
 ### Removed
 
 - Remove legacy monitoring label.

--- a/service/collector/app_operator.go
+++ b/service/collector/app_operator.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
@@ -173,6 +174,9 @@ func (a *AppOperator) collectOperatorVersions(ctx context.Context) (map[string]m
 		namespace := deploy.Namespace
 		replicas := deploy.Status.ReadyReplicas
 		version := deploy.Labels[label.AppKubernetesVersion]
+
+		// Strip any -patch suffix from the version
+		version = strings.Split(version, "-")[0]
 
 		instances, ok := operatorVersions[version]
 		if !ok {


### PR DESCRIPTION
…r versions.

When patching app operator version in an existing vintage release according to https://intranet.giantswarm.io/docs/dev-and-releng/how-to-patch-a-vintage-release-operator/ the exporter can't match the Deployment version (something like `x.y.z-patchN`) with the version apps need (just `x.y.z`).

We need to ignore the patch suffix in the deployment checkup. Hacky but no way out of this.

## Checklist

- [x] Update changelog in CHANGELOG.md.
